### PR TITLE
CORE-2006: replace `org.clojure/core.incubator` with `dev.weavejester/medley`.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.11.3"]
-                 [org.clojure/core.incubator "0.1.4"]
                  [slingshot "0.12.2"]
-                 [robert/hooke "1.3.0"]]
+                 [robert/hooke "1.3.0"]
+                 [dev.weavejester/medley "1.8.1"]]
   :eastwood {:exclude-linters [:def-in-def :unused-ret-vals]}
   :profiles {:dev {:dependencies [[midje "1.10.10"]
                                   [bultitude "0.2.8"]]}}

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/cyverse-de/dire"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.11.3"]
+  :dependencies [[org.clojure/clojure "1.11.4"]
                  [slingshot "0.12.2"]
                  [robert/hooke "1.3.0"]
                  [dev.weavejester/medley "1.8.1"]]

--- a/src/dire/core.clj
+++ b/src/dire/core.clj
@@ -1,5 +1,5 @@
 (ns dire.core
-  (:require [clojure.core.incubator :refer [dissoc-in]]
+  (:require [medley.core :refer [dissoc-in]]
             [robert.hooke :refer [add-hook remove-hook]]
             [slingshot.slingshot :refer [try+ throw+]]))
 
@@ -399,4 +399,3 @@
   (remove-wrap-hook task-var f)
   (remove-supervise task-var)
   (hook-supervisor-to-fn task-var))
-


### PR DESCRIPTION
Terrain was still complaining about replaced functions when I ran `lein eastwood` so I replaced `org.clojure/core.incubator` with `dev.weavejester/medley` instead.